### PR TITLE
Fix PEP 440 error

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -41,7 +41,7 @@ from six.moves import xrange
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.17.7.dev.synthego'
+__version__ = '0.17.7.dev'
 __license__ = 'LGPL'
 
 


### PR DESCRIPTION
### Background
- Package install failure for `Synthego-Brain`
https://github.com/Synthego/Synthego-Brain/actions/runs/4001325727/jobs/6867438109
- Package in question `https://github.com/gbiddison/python-zeroconf/zipball/master` from forked repository
- Root cause is `setuptools>=66.0.0` has a breaking change
https://setuptools.pypa.io/en/latest/history.html#v66-0-0

```
v66.0.0
15 Jan 2023

Breaking Changes
#2497: Support for PEP 440 non-conforming versions has been removed. Environments containing packages with non-conforming versions may fail or the packages may not be recognized.
```

### Changes
- Created this forked repo and changed version to satisfy PEP 440

### Open Questions/follow-up work
- We might be able to avoid using a forked repo package, and use `zeroconf==0.47.1`
- The forked repo `@gbiddison` made with his cherry picks seem to moot, see comments below for details.